### PR TITLE
fix client typing layout

### DIFF
--- a/src/assets/js/client.js
+++ b/src/assets/js/client.js
@@ -642,9 +642,18 @@ channel.bind("messaging", function(data) {
 // // listen to typing indicator
 clientListenChannel.bind("client-typing", function(data) {
     if (data.from_id == getMessengerId() && data.to_id == auth_id) {
-        data.typing == true ?
-            messagesContainer.find(".typing-indicator").show() :
-            messagesContainer.find(".typing-indicator").hide();
+        let typing = `
+        <div class="message-card typing">
+            <div class="message">
+                <span class="typing-dots">
+                    <span class="dot dot-1"></span>
+                    <span class="dot dot-2"></span>
+                    <span class="dot dot-3"></span>
+                </span>
+            </div>
+        </div>
+        `
+        data.typing == true ? $("#messages").append(typing) : $("#messages").find(".typing").remove()
     }
     // scroll to bottom
     scrollToBottom(messagesContainer);

--- a/src/views/layouts/ClientChatBox.blade.php
+++ b/src/views/layouts/ClientChatBox.blade.php
@@ -13,7 +13,7 @@ $user = App\Models\User::find($id);
     <div class="chat">
         <div class="chat-title">
             <h1>{{ $user->name }}</h1>
-            <h2>Customer Supprt</h2>
+            <h2>Customer Support</h2>
             <!--  <figure class="avatar">
         <img src="http://askavenue.com/img/17.jpg" /></figure>-->
         </div>

--- a/src/views/layouts/ClientChatBox.blade.php
+++ b/src/views/layouts/ClientChatBox.blade.php
@@ -22,18 +22,6 @@ $user = App\Models\User::find($id);
                 <div id="messages">
                     <p class="message-hint center-el"><span>Say Hi, 👋</span></p>
                 </div>
-                {{-- Typing indicator --}}
-                <div class="typing-indicator">
-                    <div class="message-card typing">
-                        <div class="message">
-                            <span class="typing-dots">
-                                <span class="dot dot-1"></span>
-                                <span class="dot dot-2"></span>
-                                <span class="dot dot-3"></span>
-                            </span>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
         <div class="message-box">


### PR DESCRIPTION
### Why?

The message input on client side can't be shown if admin is typing

**Before**
![Screenshot from 2023-12-13 05-05-21](https://github.com/tauseedzaman/laravel-customer-support/assets/42700729/97de35f3-526c-49d6-9c2d-c6685a967d22)

**After**
![Screenshot from 2023-12-13 05-03-51](https://github.com/tauseedzaman/laravel-customer-support/assets/42700729/ba0d70cc-9d45-4d71-ab86-94b451882e94)

